### PR TITLE
feat(iframes): ensure that berlin.de sources are responsive

### DIFF
--- a/source/appointments.liquid
+++ b/source/appointments.liquid
@@ -13,11 +13,14 @@ eleventyComputed:
 
 <main class="section pt-0 iframe-section">
   <div class="container">
-    <div class="columns is-mobile">
-      <div class="column is-three-quarters">
-        <iframe src="{{ service.appointment.berlin.url }}" frameborder="0"></iframe>
+    <div class="grid">
+      <div>
+        <iframe
+          title="Terminvereinbarung im Service-Portal Berlin"
+          src="{{ service.appointment.berlin.url }}"
+        ></iframe>
       </div>
-      <div class="column is-one-quarter">
+      <div>
         <div class="card mt-3">
           <div class="card-content has-background-light">
             <a href="/service/{{ service.key }}" class="has-text-primary is-size-5">Zurück zur Bürgerbox</a>

--- a/source/help.liquid
+++ b/source/help.liquid
@@ -13,11 +13,14 @@ eleventyComputed:
 
 <main class="section pt-0 iframe-section">
   <div class="container">
-    <div class="columns is-mobile">
-      <div class="column is-three-quarters">
-        <iframe src="https://service.berlin.de/dienstleistung/{{ service.key }}"></iframe>
+    <div class="grid">
+      <div>
+        <iframe
+          title="Service-Übersicht im Service-Portal Berlin"
+          src="https://service.berlin.de/dienstleistung/{{ service.key }}"
+        ></iframe>
       </div>
-      <div class="column is-one-quarter">
+      <div>
         <div class="card mt-3">
           <div class="card-content has-background-light">
             <a href="/service/{{ service.key }}" class="has-text-primary is-size-5">Zurück zur Bürgerbox</a>

--- a/source/sass/pages/_iframes.scss
+++ b/source/sass/pages/_iframes.scss
@@ -2,9 +2,20 @@
   // background color of berlin.de
   background-color: #ececec;
 
+  .grid {
+    display: grid;
+    /*
+      The iframe column has a fixed width of 766px to ensure that the Service-Portal Berlin
+      is rendered in its responsive version -> To prevent an overflow of the berlin.de container
+      which has a fixed width.
+    */
+    grid-template-columns: 766px 1fr;
+  }
+
   iframe {
     width: 100%;
     height: 100vh;
+    border: none;
   }
 
   a {


### PR DESCRIPTION
This PR takes care of an issue of the berlin.de iframes. Because the sites are only responsive from a certain width, we fix the iframe to a width where the berlin.de sites are actually responsive.