### PR TITLE
fix(help): enforce https in iframes

### DIFF
--- a/source/appointments.liquid
+++ b/source/appointments.liquid
@@ -13,5 +13,5 @@ eleventyComputed:
 
 <iframe
   title="Terminvereinbarung im Service-Portal Berlin"
-  src="{{ service.appointment.berlin.url }}"
+  src="{{ service.appointment.berlin.url }}/"
 ></iframe>

--- a/source/help.liquid
+++ b/source/help.liquid
@@ -13,5 +13,5 @@ eleventyComputed:
 
 <iframe
   title="Service-Übersicht im Service-Portal Berlin"
-  src="https://service.berlin.de/dienstleistung/{{ service.key }}"
+  src="https://service.berlin.de/dienstleistung/{{ service.key }}/"
 ></iframe>


### PR DESCRIPTION
This PR handles a [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content) issue when loading the Service-Portal Berlin iframes. It adds a [workaround](https://stackoverflow.com/a/48138576) to enforce loading the iframe content via https.