### PR TITLE
chore: update scripts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,7 @@ module.exports = function (eleventyConfig) {
   // eleventyConfig.addCollection("allcontent", function (collectionApi) {
   //   return collectionApi.getAll();
   // });
-  eleventyConfig.addWatchTarget("source/sass/");
+  eleventyConfig.addWatchTarget("source/css/");
   eleventyConfig.addWatchTarget("source/js/");
 
   eleventyConfig.addPassthroughCopy("source/fonts");

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,11 +6,12 @@ module.exports = function (eleventyConfig) {
   //   return collectionApi.getAll();
   // });
   eleventyConfig.addWatchTarget("source/css/");
-  eleventyConfig.addWatchTarget("source/js/");
+  eleventyConfig.addWatchTarget("source/js/bundle/"); // TODO: watch only specific output file
 
   eleventyConfig.addPassthroughCopy("source/fonts");
   eleventyConfig.addPassthroughCopy("source/css");
   eleventyConfig.addPassthroughCopy("source/images");
+  eleventyConfig.addPassthroughCopy({"source/js/bundle": "js"});
   eleventyConfig.addPassthroughCopy({ "source/_data/aemter.geojson": "data/aemter.geojson" });
 
   return {

--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,6 @@ _site/
 
 .DS_Store
 
-# Eleventy Sass Setup
+# Generated CSS and JS
 source/css/
+source/js/bundle/

--- a/package.json
+++ b/package.json
@@ -3,16 +3,15 @@
   "version": "1.0.0",
   "description": "static site builder for ZLB app prototype",
   "scripts": {
-    "scss": "node-sass source/sass -o source/css",
+    "scss": "node-sass source/sass --output source/css",
     "css": "postcss source/css/*.css -u autoprefixer cssnano -r -m",
-    "watch:eleventy": "eleventy --serve --quiet",
-    "watch:sass": "node-sass --watch source/sass -o source/css",
-    "dev": "npm-run-all scss --parallel watch:webpack watch:eleventy watch:sass",
-    "build": "run-s scss css webpack eleventy",
+    "sass:watch": "node-sass --watch --recursive source/sass --output source/css",
     "webpack": "webpack",
-    "watch:webpack": "webpack --watch",
-    "eleventy": "eleventy",
-    "eleventy:serve": "eleventy --serve",
+    "webpack:watch": "webpack --watch",
+    "eleventy:default": "eleventy",
+    "eleventy:watch": "eleventy --serve --quiet",
+    "dev": "npm-run-all scss webpack eleventy:default --parallel sass:watch webpack:watch eleventy:watch",
+    "build": "run-s scss css webpack eleventy:default",
     "test": "echo \"Currently no tests, so this passes.\" && exit 0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "webpack:watch": "webpack --watch",
     "eleventy:default": "eleventy",
     "eleventy:watch": "eleventy --serve --quiet",
-    "dev": "npm-run-all scss webpack eleventy:default --parallel sass:watch webpack:watch eleventy:watch",
+    "clean": "rm -rf _site",
+    "dev": "npm-run-all clean scss webpack eleventy:default --parallel sass:watch webpack:watch eleventy:watch",
     "build": "run-s scss css webpack eleventy:default",
     "test": "echo \"Currently no tests, so this passes.\" && exit 0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   output: {
     filename: "[name].js",
-    path: path.resolve(__dirname, "_site/js")
+    path: path.resolve(__dirname, "./source/js/bundle")
   },
   plugins: [
     new Dotenv()


### PR DESCRIPTION
This PR does some housekeeping and restructuring. It

- makes the available npm scripts more readable and understandable
- lets Eleventy watch all CSS and JS resources instead of using a separate process
- makes an initial clean of the local `_site` folder when developing