### PR TITLE
removed min-height for header

### DIFF
--- a/source/sass/components/_header.scss
+++ b/source/sass/components/_header.scss
@@ -4,7 +4,7 @@ header {
     top: 0;
   }
   display: flex;
-  min-height: 200px;
+  /* min-height: 200px; */
   padding-bottom: 20px !important;
   z-index: 1;
   box-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02);


### PR DESCRIPTION
I removed the min-height on the header element as currently without any search bar it takes up too much space for my taste. 